### PR TITLE
Update NPU Version to 1.13.0

### DIFF
--- a/platforms/coreultra/arl/README.md
+++ b/platforms/coreultra/arl/README.md
@@ -34,9 +34,9 @@ cd edge-developer-kit-reference-scripts/platforms/coreultra/arl
 This step will configure the basic setup of the platform. Make sure all of the requirements have been met before proceeding to the next step.
 
 ```bash
-./setup.sh
+bash setup.sh
 ```
-During installation, it may ask you to reboot your system. Reboot the system and run `./setup.sh` again. Installation is completed when you see this message:
+During installation, it may ask you to reboot your system. Reboot the system and run `bash setup.sh` again. Installation is completed when you see this message:
 > ✓ Platform configured
 
 ## Next Step

--- a/platforms/coreultra/arl/setup.sh
+++ b/platforms/coreultra/arl/setup.sh
@@ -61,7 +61,7 @@ verify_dependencies(){
 }
 
 verify_intel_gpu_package_repo(){
-    if [ ! -e /etc/apt/sources.list.d/intel-gpu-jammy.list ]; then
+    if [ ! -e /etc/apt/sources.list.d/intel-gpu-noble.list ]; then
         echo "Adding Intel GPU repository"
         wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
             sudo gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
@@ -196,7 +196,7 @@ verify_igpu_driver(){
 }
 
 verify_compute_runtime(){
-    COMPUTE_RUNTIME_VER="24.13.29138.7"
+    COMPUTE_RUNTIME_VER="24.52.32224.5"
     echo -e "\n# Verifying Intel(R) Compute Runtime drivers"
 
     echo -e "Install Intel(R) Compute Runtime drivers version: $COMPUTE_RUNTIME_VER"
@@ -247,11 +247,10 @@ verify_npu_driver(){
         else
             mkdir /tmp/npu_temp
             cd /tmp/npu_temp
-            wget https://github.com/intel/linux-npu-driver/releases/download/v1.5.1/intel-driver-compiler-npu_1.5.1.20240708-9842236399_ubuntu22.04_amd64.deb
-            wget https://github.com/intel/linux-npu-driver/releases/download/v1.5.1/intel-fw-npu_1.5.1.20240708-9842236399_ubuntu22.04_amd64.deb
-            wget https://github.com/intel/linux-npu-driver/releases/download/v1.5.1/intel-level-zero-npu_1.5.1.20240708-9842236399_ubuntu22.04_amd64.deb
-            wget https://github.com/oneapi-src/level-zero/releases/download/v1.17.6/level-zero_1.17.6+u22.04_amd64.deb
-            wget https://github.com/oneapi-src/level-zero/releases/download/v1.17.6/level-zero-devel_1.17.6+u22.04_amd64.deb
+            wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb
+            wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb
+            wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb
+            wget https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u24.04_amd64.deb
 
             sudo dpkg -i ./*.deb
                                                                                                                                                                                                  

--- a/platforms/coreultra/arl/usecases/openvino/README.md
+++ b/platforms/coreultra/arl/usecases/openvino/README.md
@@ -18,9 +18,9 @@ cd edge-developer-kit-reference-scripts/platforms/coreultra/arl/usecases/openvin
 ### 2. Run the setup script
 This script will create 2 docker images: OpenVINO™ docker image and OpenVINO™ Notebooks docker image.
 ```bash
-./setup.sh
+bash setup.sh
 ```
-During installation, it may ask you to reboot your system. Reboot the system and run `./setup.sh` again. Installation is completed when you see this message:
+During installation, it may ask you to reboot your system. Reboot the system and run `bash setup.sh` again. Installation is completed when you see this message:
 > ✓ OpenVINO™ use case Installed
 
 When you run command `docker images`, you can see the following docker images:
@@ -55,7 +55,7 @@ docker exec -it openvino_app /bin/bash
 ### OpenVINO™ Notebooks
 1. Run this command to launch OpenVINO™ Notebooks
 ```bash
-./launch_notebooks.sh
+bash launch_notebooks.sh
 ```
 2. Copy the URL printed in the terminal and open in a browser. Example output you will see in terminal:
 ```

--- a/platforms/coreultra/arl/usecases/openvino/npu_container.sh
+++ b/platforms/coreultra/arl/usecases/openvino/npu_container.sh
@@ -5,11 +5,10 @@
 
 mkdir /tmp/npu_temp
 cd /tmp/npu_temp || exit
-wget https://github.com/intel/linux-npu-driver/releases/download/v1.5.1/intel-driver-compiler-npu_1.5.1.20240708-9842236399_ubuntu22.04_amd64.deb
-wget https://github.com/intel/linux-npu-driver/releases/download/v1.5.1/intel-fw-npu_1.5.1.20240708-9842236399_ubuntu22.04_amd64.deb
-wget https://github.com/intel/linux-npu-driver/releases/download/v1.5.1/intel-level-zero-npu_1.5.1.20240708-9842236399_ubuntu22.04_amd64.deb
-wget https://github.com/oneapi-src/level-zero/releases/download/v1.17.6/level-zero_1.17.6+u22.04_amd64.deb
-wget https://github.com/oneapi-src/level-zero/releases/download/v1.17.6/level-zero-devel_1.17.6+u22.04_amd64.deb
+wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb
+wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb
+wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb
+wget https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u24.04_amd64.deb
 sudo dpkg -i ./*.deb
 
 cd /tmp || exit


### PR DESCRIPTION
 - Update NPU version from 1.5.1 to 1.13.0.
 - Use NPU binaries for Ubuntu 24.04 instead of 22.04.
 - Running Bash script using ./ requires executable permission. Replace ./ with bash command instead.