### PR TITLE
fix: removed unused gradio python package from vision language models microservice. (#440)

### DIFF
--- a/usecases/ai/microservices/vision-language-model/pixtral-12b/requirements.txt
+++ b/usecases/ai/microservices/vision-language-model/pixtral-12b/requirements.txt
@@ -17,7 +17,6 @@ transformers==4.48.0 --extra-index-url https://download.pytorch.org/whl/cpu
 # Web frameworks
 fastapi==0.115.6
 uvicorn==0.34.0
-gradio==5.11.0 --extra-index-url https://download.pytorch.org/whl/cpu
 streamlit
 
 # Other tools


### PR DESCRIPTION
fix: removed unused gradio python package from vision language models microservice. (#440)