### PR TITLE
fix: use ffmpeg-python instead of subprocess for trimming avatar video to fix bandit scan issue (#671)

### DIFF
--- a/usecases/ai/digital-avatar/backend/liveportrait/requirements.txt
+++ b/usecases/ai/digital-avatar/backend/liveportrait/requirements.txt
@@ -16,5 +16,6 @@ scikit-image==0.24.0
 pykalman==0.9.7
 pyyaml==6.0.2
 imageio[ffmpeg]==2.36.0
+ffmpeg-python==0.2.0
 
 fastapi[standard]

--- a/usecases/ai/digital-avatar/frontend/components/avatar-skins/ManageSkins.tsx
+++ b/usecases/ai/digital-avatar/frontend/components/avatar-skins/ManageSkins.tsx
@@ -185,7 +185,7 @@ const AvatarSkinCard = ({
               </Button>
             )}
             {!progressMessage ? (
-              <Button size="sm" variant="outline" onClick={() => window.open(skin.url, "_blank")}>
+              <Button size="sm" variant="outline" onClick={() => window.open(`/api/liveportrait/v1/skin/${skin.url}`, "_blank")}>
                 <Download className="h-4 w-4" />
               </Button>
             ) : <p className="text-gray-600">{progressMessage}</p>}


### PR DESCRIPTION
fix: use ffmpeg-python instead of subprocess for trimming avatar video to fix bandit scan issue (#671)