### PR TITLE
fix: update tutorial paths in README and Dockerfile for correct directory structure (#1031)

### DIFF
--- a/samples/real-time/tcc_tutorial/README.md
+++ b/samples/real-time/tcc_tutorial/README.md
@@ -68,7 +68,7 @@ Please follow the steps described in [Install the Docker Compose standalone](htt
 ```bash
 git clone https://github.com/intel/edge-developer-kit-reference-scripts.git .
 
-cd edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial/docker/docker-compose
+cd edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial/docker/docker-compose
 
 docker-compose up -d 
 
@@ -97,14 +97,14 @@ You should see a similar dashboard like the screenshot above. If the dashboard i
 To build the Docker image, run the following command in the directory containing your Dockerfile:
 
 ```bash
-cd edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial/
+cd edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial/
 docker build -t rt_linux_tutorial_image -f docker/Dockerfile.rt .
 ```
 Run the Docker container in interactive mode, to start the rt_linux_tutorial app:
 ```bash
  docker run -it --privileged --rm --network docker-compose_stats rt_linux_tutorial_image
 
-./rt_linux_tutorial -i 1000 -s 1
+sudo ./rt_linux_tutorial -i 1000 -s 1
 
  ```
  -----
@@ -112,7 +112,7 @@ Run the Docker container in interactive mode, to start the rt_linux_tutorial app
 To build the Docker image, run the following command in the directory containing your Dockerfile:
 
 ```bash
-cd edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial/
+cd edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial/
 docker build -t ai_obj_class_demo_image -f docker/Dockerfile.ai .
 ```
 Run the Docker container in interactive mode, to start the classification_demo app:

--- a/samples/real-time/tcc_tutorial/docker/Dockerfile.rt
+++ b/samples/real-time/tcc_tutorial/docker/Dockerfile.rt
@@ -69,7 +69,7 @@ WORKDIR /home/rtuser
 RUN git clone https://github.com/intel/edge-developer-kit-reference-scripts.git
 
 # Set the working directory for the non-root user
-WORKDIR /home/rtuser/edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial
+WORKDIR /home/rtuser/edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial
 
 # Build the project
 RUN make
@@ -79,9 +79,9 @@ RUN chmod +x rt_linux_tutorial
 
 # Allow root privilige to app and scripts
 USER root
-RUN echo "rtuser ALL=(ALL) NOPASSWD: /home/rtuser/edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial/rt_linux_tutorial" >> /etc/sudoers
-RUN echo "rtuser ALL=(ALL) NOPASSWD: /home/rtuser/edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial/setCacheAllocation.sh" >> /etc/sudoers
-RUN echo "rtuser ALL=(ALL) NOPASSWD: /home/rtuser/edge-developer-kit-reference-scripts/usecases/real-time/tcc_tutorial/setCoreFrequency.sh" >> /etc/sudoers
+RUN echo "rtuser ALL=(ALL) NOPASSWD: /home/rtuser/edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial/rt_linux_tutorial" >> /etc/sudoers
+RUN echo "rtuser ALL=(ALL) NOPASSWD: /home/rtuser/edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial/setCacheAllocation.sh" >> /etc/sudoers
+RUN echo "rtuser ALL=(ALL) NOPASSWD: /home/rtuser/edge-developer-kit-reference-scripts/samples/real-time/tcc_tutorial/setCoreFrequency.sh" >> /etc/sudoers
 USER rtuser
 
 # Healthcheck


### PR DESCRIPTION
fix: update tutorial paths in README and Dockerfile for correct directory structure (#1031)